### PR TITLE
Introduce Strategy interface

### DIFF
--- a/engine/evolution.py
+++ b/engine/evolution.py
@@ -2,24 +2,30 @@ import random
 from typing import List
 
 from strategies.generator import generate_random_strategy
+from strategies.moving_average import MovingAverageCrossoverStrategy
 from .evaluation import evaluate_strategy
 
 
-def crossover(parent1: dict, parent2: dict) -> dict:
+def crossover(
+    parent1: MovingAverageCrossoverStrategy,
+    parent2: MovingAverageCrossoverStrategy,
+) -> MovingAverageCrossoverStrategy:
     """Create a child strategy from two parents."""
-    return {
-        "short_window": random.choice(
-            [parent1["short_window"], parent2["short_window"]]
+    return MovingAverageCrossoverStrategy(
+        short_window=random.choice(
+            [parent1.short_window, parent2.short_window]
         ),
-        "long_window": random.choice(
-            [parent1["long_window"], parent2["long_window"]]
-        ),
-    }
+        long_window=random.choice([
+            parent1.long_window,
+            parent2.long_window,
+        ]),
+    )
 
 
 def evolve_strategies(
-    strategies: List[dict], fitness_scores: List[float]
-) -> List[dict]:
+    strategies: List[MovingAverageCrossoverStrategy],
+    fitness_scores: List[float],
+) -> List[MovingAverageCrossoverStrategy]:
     """Evolve a population of strategies based on fitness scores."""
     paired = list(zip(strategies, fitness_scores))
     paired.sort(key=lambda x: x[1], reverse=True)

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,9 @@
+from .base import Strategy
+from .moving_average import MovingAverageCrossoverStrategy
+from .generator import generate_random_strategy
+
+__all__ = [
+    "Strategy",
+    "MovingAverageCrossoverStrategy",
+    "generate_random_strategy",
+]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+import pandas as pd
+
+
+class Strategy(ABC):
+    """Abstract base class for trading strategies."""
+
+    @abstractmethod
+    def generate_signals(self, price_data: pd.Series):
+        """Return entry and exit signal series."""
+        pass

--- a/strategies/generator.py
+++ b/strategies/generator.py
@@ -1,14 +1,14 @@
 import random
 
+from .moving_average import MovingAverageCrossoverStrategy
 
-def generate_random_strategy():
+
+def generate_random_strategy() -> MovingAverageCrossoverStrategy:
     """Generate a simple moving average crossover strategy.
 
-    Returns a dictionary containing short and long moving average windows.
+    Returns an instance of :class:`MovingAverageCrossoverStrategy` with random
+    short and long moving average windows.
     """
     short_window = random.randint(5, 20)
     long_window = random.randint(short_window + 1, 60)
-    return {
-        "short_window": short_window,
-        "long_window": long_window,
-    }
+    return MovingAverageCrossoverStrategy(short_window, long_window)

--- a/strategies/moving_average.py
+++ b/strategies/moving_average.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+import pandas as pd
+import vectorbt as vbt
+from .base import Strategy
+
+
+@dataclass
+class MovingAverageCrossoverStrategy(Strategy):
+    """Simple moving average crossover strategy."""
+
+    short_window: int
+    long_window: int
+
+    def generate_signals(self, price_data: pd.Series):
+        fast_ma = vbt.MA.run(price_data, self.short_window)
+        slow_ma = vbt.MA.run(price_data, self.long_window)
+        entries = fast_ma.ma_crossed_above(slow_ma)
+        exits = fast_ma.ma_crossed_below(slow_ma)
+        return entries, exits

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from strategies.generator import generate_random_strategy
+from strategies import generate_random_strategy
 from engine.evaluation import evaluate_strategy
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,7 +1,8 @@
-from strategies.generator import generate_random_strategy
+from strategies import generate_random_strategy
 
 
 def test_generate_random_strategy_keys():
     strat = generate_random_strategy()
-    assert "short_window" in strat and "long_window" in strat
-    assert strat["short_window"] < strat["long_window"]
+    assert hasattr(strat, "short_window") and hasattr(strat, "long_window")
+    assert strat.short_window < strat.long_window
+    assert hasattr(strat, "generate_signals")


### PR DESCRIPTION
## Summary
- add `Strategy` ABC to define expected methods
- implement `MovingAverageCrossoverStrategy`
- update generator to return strategy instances
- adapt `evaluate_strategy` to use strategy objects or callables
- revise evolutionary algorithm for new strategy type
- update tests for new interface

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68647b76a1c483298e87c95176a7bd7c