### PR TITLE
Add RSI and Bollinger strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ This DataFrame can then be used as `price_data` when evaluating strategies.
 
 ## Evolving strategies
 
-Run the evolution driver to create and evolve a population of moving average
-strategies:
+Run the evolution driver to create and evolve a population of trading
+strategies. Available strategy types include moving average crossovers, RSI
+thresholds and Bollinger Band breakouts:
 
 ```bash
 python engine/evolution.py

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,9 +1,13 @@
 from .base import Strategy
 from .moving_average import MovingAverageCrossoverStrategy
+from .rsi import RSIStrategy
+from .bollinger import BollingerBandStrategy
 from .generator import generate_random_strategy
 
 __all__ = [
     "Strategy",
     "MovingAverageCrossoverStrategy",
+    "RSIStrategy",
+    "BollingerBandStrategy",
     "generate_random_strategy",
 ]

--- a/strategies/bollinger.py
+++ b/strategies/bollinger.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+import pandas as pd
+import vectorbt as vbt
+
+from .base import Strategy
+
+
+@dataclass
+class BollingerBandStrategy(Strategy):
+    """Bollinger Bands breakout strategy."""
+
+    window: int
+    std_mul: float = 2.0
+
+    def generate_signals(self, price_data: pd.Series):
+        bb = vbt.BBANDS.run(price_data, window=self.window, alpha=self.std_mul)
+        entries = bb.close_crossed_above(bb.lower)
+        exits = bb.close_crossed_below(bb.upper)
+        return entries, exits

--- a/strategies/generator.py
+++ b/strategies/generator.py
@@ -1,14 +1,26 @@
 import random
 
 from .moving_average import MovingAverageCrossoverStrategy
+from .rsi import RSIStrategy
+from .bollinger import BollingerBandStrategy
 
 
-def generate_random_strategy() -> MovingAverageCrossoverStrategy:
-    """Generate a simple moving average crossover strategy.
+def generate_random_strategy():
+    """Generate a random trading strategy instance."""
 
-    Returns an instance of :class:`MovingAverageCrossoverStrategy` with random
-    short and long moving average windows.
-    """
-    short_window = random.randint(5, 20)
-    long_window = random.randint(short_window + 1, 60)
-    return MovingAverageCrossoverStrategy(short_window, long_window)
+    choice = random.choice(["ma", "rsi", "bb"])
+
+    if choice == "ma":
+        short_window = random.randint(5, 20)
+        long_window = random.randint(short_window + 1, 60)
+        return MovingAverageCrossoverStrategy(short_window, long_window)
+
+    if choice == "rsi":
+        window = random.randint(5, 30)
+        overbought = random.randint(60, 80)
+        oversold = random.randint(20, 40)
+        return RSIStrategy(window=window, overbought=overbought, oversold=oversold)
+
+    window = random.randint(10, 30)
+    std_mul = round(random.uniform(1.5, 3.0), 1)
+    return BollingerBandStrategy(window=window, std_mul=std_mul)

--- a/strategies/rsi.py
+++ b/strategies/rsi.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+import pandas as pd
+import vectorbt as vbt
+
+from .base import Strategy
+
+
+@dataclass
+class RSIStrategy(Strategy):
+    """Relative Strength Index strategy."""
+
+    window: int
+    overbought: float = 70.0
+    oversold: float = 30.0
+
+    def generate_signals(self, price_data: pd.Series):
+        rsi = vbt.RSI.run(price_data, window=self.window)
+        entries = rsi.rsi_below(self.oversold)
+        exits = rsi.rsi_above(self.overbought)
+        return entries, exits

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,8 +1,24 @@
-from strategies import generate_random_strategy
+from unittest.mock import patch
+
+from strategies import (
+    generate_random_strategy,
+    MovingAverageCrossoverStrategy,
+    RSIStrategy,
+    BollingerBandStrategy,
+)
 
 
 def test_generate_random_strategy_keys():
     strat = generate_random_strategy()
-    assert hasattr(strat, "short_window") and hasattr(strat, "long_window")
-    assert strat.short_window < strat.long_window
     assert hasattr(strat, "generate_signals")
+
+
+def test_generator_returns_each_strategy_type():
+    with patch("strategies.generator.random.choice", side_effect=["ma", "rsi", "bb"]):
+        strat1 = generate_random_strategy()
+        strat2 = generate_random_strategy()
+        strat3 = generate_random_strategy()
+
+    assert isinstance(strat1, MovingAverageCrossoverStrategy)
+    assert isinstance(strat2, RSIStrategy)
+    assert isinstance(strat3, BollingerBandStrategy)


### PR DESCRIPTION
## Summary
- implement `RSIStrategy` and `BollingerBandStrategy`
- extend strategy generator to return any of the three strategies
- expose new strategies from the package
- update tests to cover all strategy types
- document new options in README

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648590e4948329ba6c14be50c1d12f