### PR TITLE
Fix evolution script for MA strategies

### DIFF
--- a/engine/evolution.py
+++ b/engine/evolution.py
@@ -36,7 +36,7 @@ def evolve_strategies(
     # mutate survivors
     for i, strat in enumerate(survivors):
         if random.random() < 0.2:
-            survivors[i] = generate_random_strategy()
+            survivors[i] = generate_random_strategy(["ma"])
 
     # produce children
     while len(survivors) < len(strategies):
@@ -58,7 +58,9 @@ def main():
         np.cumprod(1 + np.random.normal(0, 0.01, 300)), name="price"
     )
 
-    strategies = [generate_random_strategy() for _ in range(population_size)]
+    strategies = [
+        generate_random_strategy(["ma"]) for _ in range(population_size)
+    ]
 
     for gen in range(generations):
         fitness = [evaluate_strategy(s, price_series) for s in strategies]

--- a/strategies/generator.py
+++ b/strategies/generator.py
@@ -5,10 +5,18 @@ from .rsi import RSIStrategy
 from .bollinger import BollingerBandStrategy
 
 
-def generate_random_strategy():
-    """Generate a random trading strategy instance."""
+def generate_random_strategy(allowed_types=None):
+    """Generate a random trading strategy instance.
 
-    choice = random.choice(["ma", "rsi", "bb"])
+    Parameters
+    ----------
+    allowed_types : list[str] or None, optional
+        Restrict the strategy types that can be generated. When ``None`` all
+        available strategy types are considered.
+    """
+
+    choices = ["ma", "rsi", "bb"] if allowed_types is None else allowed_types
+    choice = random.choice(choices)
 
     if choice == "ma":
         short_window = random.randint(5, 20)


### PR DESCRIPTION
## Summary
- support restricting generated strategy types
- evolve only moving average strategies in the sample driver
- run evolution script

## Testing
- `pytest -q`
- `python -m engine.evolution`

------
https://chatgpt.com/codex/tasks/task_e_686488e3b4748329807fe7960ffe84e0